### PR TITLE
Add GitHub commit logic to EC2 API

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,40 @@
+# Internal Developer Platform App
+
+This is a minimal Next.js application that exposes a simple interface for managing EC2 instances. Actions are executed using the AWS SDK and credentials provided via environment variables.
+
+## Setup
+
+1. Install dependencies
+   ```
+   npm install
+   ```
+2. Start the dev server
+   ```
+   npm run dev
+   ```
+
+Set the following environment variables if you want new instances to be
+committed automatically to GitHub:
+
+```bash
+export GITHUB_TOKEN=<your PAT>
+export GITHUB_OWNER=<github owner>
+export GITHUB_REPO=<repository name>
+# optional
+export GITHUB_BRANCH=main
+```
+
+## API
+
+POST `/api/ec2`
+
+Request body:
+```
+{
+  "action": "create|start|stop|terminate",
+  "instanceName": "optional when action=create",
+  "instanceId": "optional when action!=create"
+}
+```
+
+When `action` is `create`, a `terraform.tfvars` file is written to `terraform/terraform.tfvars` with the provided `instanceName`. If the environment variables `GITHUB_TOKEN`, `GITHUB_OWNER`, and `GITHUB_REPO` are set (and optionally `GITHUB_BRANCH`), the file is also committed to the specified GitHub repository using the GitHub API.

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "internal-developer-platform-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@aws-sdk/client-ec2": "3.567.0"
+  }
+}

--- a/app/pages/api/ec2.js
+++ b/app/pages/api/ec2.js
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+import { EC2Client, StartInstancesCommand, StopInstancesCommand, TerminateInstancesCommand } from '@aws-sdk/client-ec2';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { action, instanceId, instanceName } = req.body;
+  const client = new EC2Client({ region: process.env.AWS_REGION || 'us-east-1' });
+
+  try {
+    if (action === 'create') {
+      const tfvarsPath = path.join(process.cwd(), 'terraform', 'terraform.tfvars');
+      fs.writeFileSync(tfvarsPath, `instance_name = "${instanceName}"`);
+
+      const token = process.env.GITHUB_TOKEN;
+      const owner = process.env.GITHUB_OWNER;
+      const repo = process.env.GITHUB_REPO;
+      const branch = process.env.GITHUB_BRANCH || 'main';
+
+      if (token && owner && repo) {
+        const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/terraform/terraform.tfvars`;
+
+        const headers = {
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'idf-app',
+          Accept: 'application/vnd.github+json',
+        };
+
+        // Attempt to read existing file to get its SHA
+        const currentRes = await fetch(`${apiUrl}?ref=${branch}`, { headers });
+        let sha;
+        if (currentRes.ok) {
+          const currentData = await currentRes.json();
+          sha = currentData.sha;
+        }
+
+        const content = fs.readFileSync(tfvarsPath, 'utf8');
+        await fetch(apiUrl, {
+          method: 'PUT',
+          headers,
+          body: JSON.stringify({
+            message: `Update terraform.tfvars for ${instanceName}`,
+            content: Buffer.from(content).toString('base64'),
+            branch,
+            ...(sha ? { sha } : {}),
+          }),
+        });
+      }
+    } else if (action === 'start') {
+      await client.send(new StartInstancesCommand({ InstanceIds: [instanceId] }));
+    } else if (action === 'stop') {
+      await client.send(new StopInstancesCommand({ InstanceIds: [instanceId] }));
+    } else if (action === 'terminate') {
+      await client.send(new TerminateInstancesCommand({ InstanceIds: [instanceId] }));
+    } else {
+      throw new Error('Unknown action');
+    }
+
+    res.status(200).json({ status: 'ok' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/app/pages/index.js
+++ b/app/pages/index.js
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [instanceName, setInstanceName] = useState('');
+  const [instanceId, setInstanceId] = useState('');
+  const [message, setMessage] = useState('');
+
+  const callApi = async (action) => {
+    const body = { action };
+    if (action === 'create') body.instanceName = instanceName;
+    else body.instanceId = instanceId;
+
+    const res = await fetch('/api/ec2', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (res.ok) setMessage('Success');
+    else setMessage(data.error || 'Error');
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>EC2 Manager</h1>
+      <div>
+        <h2>Create Instance</h2>
+        <input placeholder="Instance name" value={instanceName} onChange={e => setInstanceName(e.target.value)} />
+        <button onClick={() => callApi('create')}>Create</button>
+      </div>
+      <div style={{ marginTop: '2rem' }}>
+        <h2>Manage Instance</h2>
+        <input placeholder="Instance ID" value={instanceId} onChange={e => setInstanceId(e.target.value)} />
+        <button onClick={() => callApi('start')}>Start</button>
+        <button onClick={() => callApi('stop')}>Stop</button>
+        <button onClick={() => callApi('terminate')}>Terminate</button>
+      </div>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- update API logic to optionally commit terraform vars to GitHub
- document required environment variables for GitHub committing

## Testing
- `npm --prefix app run build` *(fails: next not found / network)*

------
https://chatgpt.com/codex/tasks/task_b_685474fb222c83308783a3d9a7f4f400